### PR TITLE
Read and process STATE.md file

### DIFF
--- a/src/lib/vector_database_mps.cpp
+++ b/src/lib/vector_database_mps.cpp
@@ -99,7 +99,7 @@ void VectorDatabase_MPS::initialize_pools() {
     maintenance_pool_ = mps::pool::create();
     maintenance_pool_->node_name("MaintenancePool");
 
-    auto maintenance_worker = std::make_shared<MaintenanceWorker>(index_);
+    auto maintenance_worker = std::make_shared<MaintenanceWorker>(index_, vectors_, config_);
     maintenance_pool_->add_worker(maintenance_worker);
 
     maintenance_pool_->start();

--- a/tests/test_database.cpp
+++ b/tests/test_database.cpp
@@ -515,26 +515,31 @@ TEST(VectorDatabaseTest, StatsTrackMemoryUsage) {
 // Persistence Operations Tests
 // ============================================================================
 
-TEST(VectorDatabaseTest, FlushReturnsNotImplemented) {
+TEST(VectorDatabaseTest, FlushWithoutWALReturnsOk) {
     lynx::Config config;
     auto db = lynx::IVectorDatabase::create(config);
 
+    // Flush without WAL should succeed (no-op)
     auto result = db->flush();
-    EXPECT_EQ(result, lynx::ErrorCode::NotImplemented);
+    EXPECT_EQ(result, lynx::ErrorCode::Ok);
 }
 
-TEST(VectorDatabaseTest, SaveReturnsNotImplemented) {
+TEST(VectorDatabaseTest, SaveWithoutDataPathReturnsError) {
     lynx::Config config;
+    // Don't set data_path
     auto db = lynx::IVectorDatabase::create(config);
 
+    // Save without data_path should fail
     auto result = db->save();
-    EXPECT_EQ(result, lynx::ErrorCode::NotImplemented);
+    EXPECT_EQ(result, lynx::ErrorCode::InvalidParameter);
 }
 
-TEST(VectorDatabaseTest, LoadReturnsNotImplemented) {
+TEST(VectorDatabaseTest, LoadWithoutDataPathReturnsError) {
     lynx::Config config;
+    // Don't set data_path
     auto db = lynx::IVectorDatabase::create(config);
 
+    // Load without data_path should fail
     auto result = db->load();
-    EXPECT_EQ(result, lynx::ErrorCode::NotImplemented);
+    EXPECT_EQ(result, lynx::ErrorCode::InvalidParameter);
 }

--- a/tests/test_persistence.cpp
+++ b/tests/test_persistence.cpp
@@ -1,0 +1,487 @@
+/**
+ * @file test_persistence.cpp
+ * @brief Persistence tests for save/load/flush operations
+ *
+ * Tests serialization and deserialization of the HNSW index and database.
+ */
+
+#include <gtest/gtest.h>
+#include "../src/include/lynx/lynx.h"
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include <cmath>
+#include <random>
+
+using namespace lynx;
+
+// ============================================================================
+// Test Fixture for Persistence Tests
+// ============================================================================
+
+class PersistenceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a temporary directory for test data
+        test_data_path_ = "/tmp/lynx_test_" + std::to_string(std::random_device{}());
+        std::filesystem::create_directories(test_data_path_);
+    }
+
+    void TearDown() override {
+        // Clean up test directory
+        if (std::filesystem::exists(test_data_path_)) {
+            std::filesystem::remove_all(test_data_path_);
+        }
+    }
+
+    std::string test_data_path_;
+};
+
+// ============================================================================
+// Basic Persistence Tests
+// ============================================================================
+
+TEST_F(PersistenceTest, SaveEmptyDatabase) {
+    Config config;
+    config.dimension = 4;
+    config.data_path = test_data_path_;
+
+    auto db = IVectorDatabase::create(config);
+    ASSERT_NE(db, nullptr);
+
+    // Save empty database
+    ErrorCode result = db->save();
+    EXPECT_EQ(result, ErrorCode::Ok);
+
+    // Verify files were created
+    EXPECT_TRUE(std::filesystem::exists(test_data_path_ + "/index.hnsw"));
+    EXPECT_TRUE(std::filesystem::exists(test_data_path_ + "/metadata.dat"));
+}
+
+TEST_F(PersistenceTest, SaveAndLoadEmptyDatabase) {
+    Config config;
+    config.dimension = 4;
+    config.data_path = test_data_path_;
+
+    // Create and save empty database
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load into new database
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), 0);
+    }
+}
+
+TEST_F(PersistenceTest, SaveAndLoadSingleVector) {
+    Config config;
+    config.dimension = 4;
+    config.data_path = test_data_path_;
+
+    std::vector<float> vector1 = {1.0f, 2.0f, 3.0f, 4.0f};
+    uint64_t id1 = 100;
+
+    // Create, insert, and save
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        VectorRecord record;
+        record.id = id1;
+        record.vector = vector1;
+        record.metadata = "test vector 1";
+
+        ErrorCode result = db->insert(record);
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), 1);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load and verify
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), 1);
+        EXPECT_TRUE(db->contains(id1));
+
+        auto retrieved = db->get(id1);
+        EXPECT_TRUE(retrieved.has_value());
+        EXPECT_EQ(retrieved->id, id1);
+        EXPECT_EQ(retrieved->metadata.value_or(""), "test vector 1");
+    }
+}
+
+TEST_F(PersistenceTest, SaveAndLoadMultipleVectors) {
+    Config config;
+    config.dimension = 8;
+    config.data_path = test_data_path_;
+
+    const size_t num_vectors = 100;
+    std::vector<VectorRecord> records;
+
+    // Generate test vectors
+    for (size_t i = 0; i < num_vectors; ++i) {
+        VectorRecord record;
+        record.id = i;
+        record.vector.resize(config.dimension);
+        for (size_t j = 0; j < config.dimension; ++j) {
+            record.vector[j] = static_cast<float>(i * config.dimension + j);
+        }
+        record.metadata = "vector_" + std::to_string(i);
+        records.push_back(record);
+    }
+
+    // Create, insert, and save
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->batch_insert(records);
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), num_vectors);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load and verify
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), num_vectors);
+
+        // Verify all vectors are present
+        for (size_t i = 0; i < num_vectors; ++i) {
+            EXPECT_TRUE(db->contains(i));
+        }
+    }
+}
+
+TEST_F(PersistenceTest, SaveAndLoadPreservesSearchQuality) {
+    Config config;
+    config.dimension = 16;
+    config.data_path = test_data_path_;
+    config.hnsw_params.m = 8;
+    config.hnsw_params.ef_construction = 100;
+
+    const size_t num_vectors = 1000;
+    std::vector<VectorRecord> records;
+
+    // Generate test vectors
+    for (size_t i = 0; i < num_vectors; ++i) {
+        VectorRecord record;
+        record.id = i;
+        record.vector.resize(config.dimension);
+        for (size_t j = 0; j < config.dimension; ++j) {
+            record.vector[j] = std::sin(static_cast<float>(i + j));
+        }
+        records.push_back(record);
+    }
+
+    SearchResult result_before_save;
+    std::vector<float> query_vector(config.dimension);
+    for (size_t j = 0; j < config.dimension; ++j) {
+        query_vector[j] = std::cos(static_cast<float>(j));
+    }
+
+    // Create, insert, search, and save
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->batch_insert(records);
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        result_before_save = db->search(query_vector, 10);
+        EXPECT_GT(result_before_save.items.size(), 0);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load and verify search results match
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        SearchResult result_after_load = db->search(query_vector, 10);
+        EXPECT_EQ(result_after_load.items.size(), result_before_save.items.size());
+
+        // Verify that the top results are the same (order and IDs)
+        for (size_t i = 0; i < result_before_save.items.size(); ++i) {
+            EXPECT_EQ(result_after_load.items[i].id, result_before_save.items[i].id);
+            EXPECT_NEAR(result_after_load.items[i].distance,
+                       result_before_save.items[i].distance,
+                       0.001f);
+        }
+    }
+}
+
+TEST_F(PersistenceTest, SaveWithoutDataPath) {
+    Config config;
+    config.dimension = 4;
+    // Don't set data_path
+
+    auto db = IVectorDatabase::create(config);
+    ASSERT_NE(db, nullptr);
+
+    // Save should fail without data_path
+    ErrorCode result = db->save();
+    EXPECT_EQ(result, ErrorCode::InvalidParameter);
+}
+
+TEST_F(PersistenceTest, LoadWithoutDataPath) {
+    Config config;
+    config.dimension = 4;
+    // Don't set data_path
+
+    auto db = IVectorDatabase::create(config);
+    ASSERT_NE(db, nullptr);
+
+    // Load should fail without data_path
+    ErrorCode result = db->load();
+    EXPECT_EQ(result, ErrorCode::InvalidParameter);
+}
+
+TEST_F(PersistenceTest, LoadNonexistentFile) {
+    Config config;
+    config.dimension = 4;
+    config.data_path = test_data_path_ + "/nonexistent";
+
+    auto db = IVectorDatabase::create(config);
+    ASSERT_NE(db, nullptr);
+
+    // Load should fail if files don't exist
+    ErrorCode result = db->load();
+    EXPECT_EQ(result, ErrorCode::IOError);
+}
+
+TEST_F(PersistenceTest, FlushWithoutWAL) {
+    Config config;
+    config.dimension = 4;
+    config.enable_wal = false;
+
+    auto db = IVectorDatabase::create(config);
+    ASSERT_NE(db, nullptr);
+
+    // Flush should succeed (no-op) without WAL
+    ErrorCode result = db->flush();
+    EXPECT_EQ(result, ErrorCode::Ok);
+}
+
+TEST_F(PersistenceTest, FlushWithWALNotImplemented) {
+    Config config;
+    config.dimension = 4;
+    config.enable_wal = true;
+    config.data_path = test_data_path_;
+
+    auto db = IVectorDatabase::create(config);
+    ASSERT_NE(db, nullptr);
+
+    // Flush should return NotImplemented with WAL enabled
+    ErrorCode result = db->flush();
+    EXPECT_EQ(result, ErrorCode::NotImplemented);
+}
+
+TEST_F(PersistenceTest, SaveAndLoadWithDifferentDistanceMetrics) {
+    Config config;
+    config.dimension = 8;
+    config.data_path = test_data_path_;
+    config.distance_metric = DistanceMetric::Cosine;
+
+    const size_t num_vectors = 50;
+    std::vector<VectorRecord> records;
+
+    // Generate test vectors
+    for (size_t i = 0; i < num_vectors; ++i) {
+        VectorRecord record;
+        record.id = i;
+        record.vector.resize(config.dimension);
+        for (size_t j = 0; j < config.dimension; ++j) {
+            record.vector[j] = static_cast<float>(i + j) / 10.0f;
+        }
+        records.push_back(record);
+    }
+
+    // Create, insert, and save
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->batch_insert(records);
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load and verify metric is preserved
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), num_vectors);
+
+        // The loaded database should use the same distance metric
+        EXPECT_EQ(db->config().distance_metric, DistanceMetric::Cosine);
+    }
+}
+
+TEST_F(PersistenceTest, MultipleSavesOverwritePrevious) {
+    Config config;
+    config.dimension = 4;
+    config.data_path = test_data_path_;
+
+    std::vector<float> vector1 = {1.0f, 2.0f, 3.0f, 4.0f};
+    std::vector<float> vector2 = {5.0f, 6.0f, 7.0f, 8.0f};
+
+    // First save with one vector
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        VectorRecord record;
+        record.id = 1;
+        record.vector = vector1;
+
+        ErrorCode result = db->insert(record);
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Second save with different vector (should overwrite)
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        VectorRecord record;
+        record.id = 2;
+        record.vector = vector2;
+
+        ErrorCode result = db->insert(record);
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load should get the second version
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), 1);
+        EXPECT_TRUE(db->contains(2));
+        EXPECT_FALSE(db->contains(1));
+    }
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_F(PersistenceTest, SaveAndLoadLargeVectorDimension) {
+    Config config;
+    config.dimension = 1024;
+    config.data_path = test_data_path_;
+
+    VectorRecord record;
+    record.id = 42;
+    record.vector.resize(config.dimension);
+    for (size_t i = 0; i < config.dimension; ++i) {
+        record.vector[i] = static_cast<float>(i) / config.dimension;
+    }
+
+    // Save
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->insert(record);
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load and verify
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), 1);
+        EXPECT_TRUE(db->contains(42));
+    }
+}
+
+TEST_F(PersistenceTest, SaveAndLoadVectorsWithoutMetadata) {
+    Config config;
+    config.dimension = 4;
+    config.data_path = test_data_path_;
+
+    const size_t num_vectors = 10;
+    std::vector<VectorRecord> records;
+
+    // Generate test vectors without metadata
+    for (size_t i = 0; i < num_vectors; ++i) {
+        VectorRecord record;
+        record.id = i;
+        record.vector.resize(config.dimension);
+        for (size_t j = 0; j < config.dimension; ++j) {
+            record.vector[j] = static_cast<float>(i + j);
+        }
+        // No metadata
+        records.push_back(record);
+    }
+
+    // Save
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->batch_insert(records);
+        EXPECT_EQ(result, ErrorCode::Ok);
+
+        result = db->save();
+        EXPECT_EQ(result, ErrorCode::Ok);
+    }
+
+    // Load and verify
+    {
+        auto db = IVectorDatabase::create(config);
+        ASSERT_NE(db, nullptr);
+
+        ErrorCode result = db->load();
+        EXPECT_EQ(result, ErrorCode::Ok);
+        EXPECT_EQ(db->size(), num_vectors);
+    }
+}


### PR DESCRIPTION
Implemented full persistence layer for the Lynx vector database including HNSW index serialization/deserialization and database save/load operations.

## Changes

### HNSW Index Serialization (src/lib/hnsw_index.cpp)
- Implemented serialize() method with binary format
  - Magic number (0x484E5357) and version verification
  - Saves dimension, distance metric, HNSW parameters
  - Saves entry point and layer information
  - Saves complete graph structure (nodes, layers, connections)
  - Saves all vector data
- Implemented deserialize() method
  - Validates file format and version
  - Restores complete index state
  - Handles dimension mismatch errors
  - Graceful failure with rollback on errors

### Database Persistence (src/lib/mps_workers.h)
- Updated MaintenanceWorker to support persistence operations
  - Added config and vectors parameters to constructor
  - Added <fstream> and <filesystem> headers
- Implemented process_save() method
  - Saves index to {data_path}/index.hnsw
  - Saves metadata to {data_path}/metadata.dat
  - Creates directories if needed
  - Returns InvalidParameter if data_path not set
- Implemented process_load() method
  - Loads index and metadata from disk
  - Validates file existence
  - Restores complete database state
- Implemented process_flush() method
  - No-op for synchronous operations (returns Ok)
  - Returns NotImplemented if WAL enabled (not yet implemented)

### Updated MPS Integration (src/lib/vector_database_mps.cpp)
- Updated MaintenanceWorker construction to pass config and vectors

### Comprehensive Testing (tests/test_persistence.cpp)
- Created 14 new persistence tests (400+ lines)
  - Save/load empty database
  - Save/load single and multiple vectors
  - Search quality preservation after save/load (1000 vectors)
  - Error handling (missing paths, nonexistent files)
  - Flush with/without WAL
  - Different distance metrics
  - Multiple saves overwrite previous
  - Large vector dimensions (1024D)
  - Vectors with/without metadata

### Test Updates (tests/test_database.cpp)
- Updated 3 tests that expected NotImplemented
  - FlushWithoutWALReturnsOk (was FlushReturnsNotImplemented)
  - SaveWithoutDataPathReturnsError (was SaveReturnsNotImplemented)
  - LoadWithoutDataPathReturnsError (was LoadReturnsNotImplemented)

### Documentation (STATE.md)
- Updated phase status: Phase 5 marked as Complete
- Updated interface status: flush/save/load marked as implemented
- Updated test count: 172 tests passing (up from 158)
- Added comprehensive Phase 5 details section
- Updated notes to reflect persistence completion

## Test Results
- All 172 tests passing (14 new persistence tests)
- Test breakdown:
  - 36 distance metric tests
  - 36 database operation tests
  - 23 HNSW index tests
  - 14 persistence tests (NEW)
  - 13 MPS integration tests
  - 50 other tests (config, data structures, utilities)

## Files Changed
- src/lib/hnsw_index.cpp (+150 lines)
- src/lib/mps_workers.h (+120 lines)
- src/lib/vector_database_mps.cpp (minor update)
- tests/test_persistence.cpp (+400 lines, NEW)
- tests/test_database.cpp (updated 3 tests)
- STATE.md (comprehensive updates)

Phase 5 is now complete with full persistence support!