### PR TITLE
Update setup and documentation for MPS and Google Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,48 @@ include_directories(${CMAKE_SOURCE_DIR}/src/include)
 find_package(Threads REQUIRED)
 
 # MPS library (Message Processing System)
-# TODO: Add proper find module or fetch content for MPS
-# For now, assume MPS is installed in system or specified via MPS_DIR
-if(DEFINED MPS_DIR)
+# Check multiple locations in order of priority:
+# 1. MPS_PATH environment variable or CMake variable
+# 2. MPS_DIR environment variable or CMake variable
+# 3. external/mps directory in project root
+
+set(MPS_FOUND FALSE)
+
+# Check MPS_PATH first (environment or CMake variable)
+if(DEFINED ENV{MPS_PATH} AND EXISTS "$ENV{MPS_PATH}/src")
+    set(MPS_DIR "$ENV{MPS_PATH}")
+    set(MPS_FOUND TRUE)
+    message(STATUS "Using MPS from MPS_PATH: ${MPS_DIR}")
+elseif(DEFINED MPS_PATH AND EXISTS "${MPS_PATH}/src")
+    set(MPS_DIR "${MPS_PATH}")
+    set(MPS_FOUND TRUE)
+    message(STATUS "Using MPS from MPS_PATH: ${MPS_DIR}")
+# Check MPS_DIR (environment or CMake variable)
+elseif(DEFINED ENV{MPS_DIR} AND EXISTS "$ENV{MPS_DIR}/src")
+    set(MPS_DIR "$ENV{MPS_DIR}")
+    set(MPS_FOUND TRUE)
+    message(STATUS "Using MPS from MPS_DIR: ${MPS_DIR}")
+elseif(DEFINED MPS_DIR AND EXISTS "${MPS_DIR}/src")
+    set(MPS_FOUND TRUE)
+    message(STATUS "Using MPS from MPS_DIR: ${MPS_DIR}")
+# Check external/mps directory
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/external/mps/src")
+    set(MPS_DIR "${CMAKE_SOURCE_DIR}/external/mps")
+    set(MPS_FOUND TRUE)
+    message(STATUS "Using MPS from external/mps")
+endif()
+
+if(MPS_FOUND)
     include_directories(${MPS_DIR}/src)
-    message(STATUS "MPS directory: ${MPS_DIR}")
 else()
-    message(WARNING "MPS_DIR not specified. Set -DMPS_DIR=/path/to/mps")
+    message(FATAL_ERROR
+        "MPS library not found!\n"
+        "Please either:\n"
+        "  1. Set MPS_PATH environment variable: export MPS_PATH=/path/to/mps\n"
+        "  2. Set MPS_DIR environment variable: export MPS_DIR=/path/to/mps\n"
+        "  3. Run ./setup.sh to automatically clone MPS to external/mps\n"
+        "  4. Manually clone MPS: git clone https://github.com/Alexk-195/mps.git external/mps"
+    )
 endif()
 
 # Lynx static library

--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ A high-performance vector database implemented in modern C++20 with support for 
 
 - C++20 compatible compiler (GCC 11+, Clang 14+)
 - GNU Make or CMake 3.20+
-- MPS library ([github.com/Alexk-195/mps](https://github.com/Alexk-195/mps))
-- Google Test v1.15.2 (automatically included)
+- Git (for automatic dependency cloning)
+
+### Dependencies (Auto-managed)
+
+The following dependencies are **automatically handled** by the build scripts:
+
+- **MPS library** ([github.com/Alexk-195/mps](https://github.com/Alexk-195/mps))
+  - Checked in order: `MPS_PATH` env var → `MPS_DIR` env var → `external/mps` → auto-clone
+- **Google Test v1.15.2** ([github.com/google/googletest](https://github.com/google/googletest))
+  - Automatically cloned to `external/googletest` or fetched by CMake
 
 ## Quick Start
 
@@ -25,19 +33,30 @@ A high-performance vector database implemented in modern C++20 with support for 
 git clone https://github.com/Alexk-195/lynx_vector_db.git
 cd lynx_vector_db
 
-# Clone dependencies
-git clone https://github.com/Alexk-195/mps.git ../mps
-git clone --depth 1 --branch v1.15.2 https://github.com/google/googletest.git external/googletest
-
-export MPS_DIR=$(pwd)/../mps
-
-# Build with Make (recommended)
+# Build with setup.sh (recommended - handles all dependencies automatically)
 ./setup.sh
 
-# OR build with CMake
+# OR build with CMake (dependencies auto-detected or fetched)
 mkdir build && cd build
 cmake ..
 cmake --build .
+```
+
+### Custom Dependency Locations
+
+If you have MPS installed elsewhere, set the environment variable:
+
+```bash
+# Option 1: Use MPS_PATH
+export MPS_PATH=/path/to/mps
+./setup.sh
+
+# Option 2: Use MPS_DIR (legacy)
+export MPS_DIR=/path/to/mps
+./setup.sh
+
+# Option 3: Let setup.sh auto-clone to external/mps (no env var needed)
+./setup.sh
 ```
 
 ### Build Options - setup.sh (Makefile)
@@ -62,19 +81,22 @@ make clean        # Clean build
 make run          # Build and run
 make info         # Show build configuration
 
-# With MPS library
-export MPS_DIR=/path/to/mps
+# Note: MPS_DIR is automatically set by setup.sh
+# If using make directly, set MPS_PATH or MPS_DIR manually
+export MPS_PATH=/path/to/mps
 make
 ```
 
 ### Build Options - CMake
 
 ```bash
-# Configure
+# Configure (dependencies auto-detected)
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 
-# With MPS
+# With custom MPS location (if needed)
+cmake .. -DMPS_PATH=/path/to/mps
+# OR
 cmake .. -DMPS_DIR=/path/to/mps
 
 # Build


### PR DESCRIPTION
Enhanced setup.sh and CMakeLists.txt to provide flexible dependency resolution with automatic fallback to cloning.

Changes:
- setup.sh: Check MPS_PATH env var first, then MPS_DIR, then auto-clone to external/mps
- setup.sh: Auto-clone Google Test to external/googletest if not present
- CMakeLists.txt: Check MPS_PATH, MPS_DIR, and external/mps with clear error messages
- README.md: Document automatic dependency management and new MPS_PATH variable

Dependency resolution order:
1. MPS_PATH environment variable
2. MPS_DIR environment variable (legacy)
3. external/mps directory (auto-cloned)

This simplifies the build process - users can now just run ./setup.sh without manually cloning dependencies.