### PR TITLE
Optimize search_layer to return vector instead of priority_queue

### DIFF
--- a/src/lib/hnsw_index.h
+++ b/src/lib/hnsw_index.h
@@ -189,10 +189,9 @@ private:
      * @param entry_points Starting nodes for search
      * @param ef Number of neighbors to explore
      * @param layer Layer to search in
-     * @return Priority queue of (id, distance) candidates
+     * @return Vector of (id, distance) candidates, sorted by distance ascending
      */
-    std::priority_queue<Candidate, std::vector<Candidate>, std::less<Candidate>>
-    search_layer(
+    [[nodiscard]] std::vector<Candidate> search_layer(
         std::span<const float> query,
         const std::vector<std::uint64_t>& entry_points,
         std::size_t ef,


### PR DESCRIPTION
- Return std::vector<Candidate> sorted by distance (closest first)
- Eliminates wasteful heap-to-heap conversion in add()
- Uses move semantics when building min-heap from result vector
- Simplifies search() - no more reverse iteration needed
- Pre-reserve visited set for better performance
- Uses std::make_heap/push_heap/pop_heap on vector for internal tracking

This enables true move semantics and avoids O(n) element copying when converting between different heap types.