### PR TITLE
Fix StatsTrackMemoryUsage test to account for index overhead

### DIFF
--- a/tests/test_database.cpp
+++ b/tests/test_database.cpp
@@ -516,13 +516,16 @@ TEST(VectorDatabaseTest, StatsTrackMemoryUsage) {
     config.dimension = 100;
     auto db = lynx::IVectorDatabase::create(config);
 
+    // Get initial memory usage (may include index overhead like HNSW's visited_table_)
     auto stats1 = db->stats();
-    EXPECT_EQ(stats1.memory_usage_bytes, 0);
+    std::size_t initial_memory = stats1.memory_usage_bytes;
 
+    // Insert a vector
     db->insert({1, std::vector<float>(100, 1.0f), std::nullopt});
 
+    // Memory should increase after insertion
     auto stats2 = db->stats();
-    EXPECT_GT(stats2.memory_usage_bytes, 0);
+    EXPECT_GT(stats2.memory_usage_bytes, initial_memory);
 }
 
 // ============================================================================


### PR DESCRIPTION
The test was failing because it expected memory_usage_bytes to be exactly 0 before any vectors are inserted. However, indices have legitimate initial overhead:
- HNSW pre-allocates a 1024-byte visited_table_ for performance
- Flat includes sizeof(FlatIndex) in its memory calculations

Changed the test to:
- Store the initial memory usage (which may include index overhead)
- Verify that memory increases after vector insertion
- This is a more robust test that doesn't make assumptions about exact initial allocations

Root cause: HNSW index initializes visited_table_(1024) in constructor (hnsw_index.cpp:57) and reports it in memory_usage() (hnsw_index.cpp:668).

Fixes test: VectorDatabaseTest.StatsTrackMemoryUsage