### PR TITLE
Remove all MPS references from documentation and build files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,7 @@
 ## Project Overview
 
 Lynx is a high-performance vector database implemented in modern C++20 with a unified architecture:
-- **Default**: `VectorDatabase` with `std::shared_mutex` for thread safety (simple, sufficient for most use cases)
-- **Advanced**: `VectorDatabase_MPS` using message-passing for extreme concurrency (100+ queries)
+- **Default**: `VectorDatabase` with `std::shared_mutex` for thread safety
 - **Indices**: Pluggable index implementations (Flat, HNSW, IVF) through a single database class
 
 ## Required Reading
@@ -59,22 +58,6 @@ The default `VectorDatabase` uses:
 - Concurrent reads (multiple searches simultaneously)
 - Exclusive writes (inserts/removes serialized)
 - Works with all index types (Flat, HNSW, IVF)
-
-### Advanced: MPS Integration (Optional)
-
-For extreme performance (100+ concurrent queries), `VectorDatabase_MPS` is available:
-- Message-passing architecture with dedicated thread pools
-- Non-blocking index optimization
-- Key MPS concepts:
-  - `mps::pool` - Thread + message queue
-  - `mps::worker` - Processes messages via `process()` method
-  - `mps::message` - Base class for all messages
-
-**When to use**:
-- Default `VectorDatabase` for most use cases
-- `VectorDatabase_MPS` only when profiling shows lock contention or need non-blocking maintenance
-
-See `doc/MPS_ARCHITECTURE.md` for details.
 
 ## Testing
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,57 +55,6 @@ include_directories(${CMAKE_SOURCE_DIR}/src/include)
 # Find required packages
 find_package(Threads REQUIRED)
 
-# MPS library (Message Processing System)
-# Check multiple locations in order of priority:
-# 1. MPS_PATH environment variable or CMake variable
-# 2. MPS_DIR environment variable or CMake variable
-# 3. external/mps directory in project root
-
-set(MPS_FOUND FALSE)
-
-# Check MPS_PATH first (environment or CMake variable)
-if(DEFINED ENV{MPS_PATH} AND EXISTS "$ENV{MPS_PATH}/src")
-    set(MPS_DIR "$ENV{MPS_PATH}")
-    set(MPS_FOUND TRUE)
-    message(STATUS "Using MPS from MPS_PATH: ${MPS_DIR}")
-elseif(DEFINED MPS_PATH AND EXISTS "${MPS_PATH}/src")
-    set(MPS_DIR "${MPS_PATH}")
-    set(MPS_FOUND TRUE)
-    message(STATUS "Using MPS from MPS_PATH: ${MPS_DIR}")
-# Check MPS_DIR (environment or CMake variable)
-elseif(DEFINED ENV{MPS_DIR} AND EXISTS "$ENV{MPS_DIR}/src")
-    set(MPS_DIR "$ENV{MPS_DIR}")
-    set(MPS_FOUND TRUE)
-    message(STATUS "Using MPS from MPS_DIR: ${MPS_DIR}")
-elseif(DEFINED MPS_DIR AND EXISTS "${MPS_DIR}/src")
-    set(MPS_FOUND TRUE)
-    message(STATUS "Using MPS from MPS_DIR: ${MPS_DIR}")
-# Check external/mps directory
-elseif(EXISTS "${CMAKE_SOURCE_DIR}/external/mps/src")
-    set(MPS_DIR "${CMAKE_SOURCE_DIR}/external/mps")
-    set(MPS_FOUND TRUE)
-    message(STATUS "Using MPS from external/mps")
-endif()
-
-if(MPS_FOUND)
-    include_directories(${MPS_DIR}/src)
-
-    # Build MPS as a static library
-    add_library(mps_static STATIC ${MPS_DIR}/src/mps.cpp)
-    target_include_directories(mps_static PUBLIC ${MPS_DIR}/src)
-    target_link_libraries(mps_static PUBLIC Threads::Threads)
-    set_target_properties(mps_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
-else()
-    message(FATAL_ERROR
-        "MPS library not found!\n"
-        "Please either:\n"
-        "   1. Set MPS_PATH environment variable: export MPS_PATH=/path/to/mps\n"
-        "   2. Set MPS_DIR environment variable: export MPS_DIR=/path/to/mps\n"
-        "   3. Run ./setup.sh to automatically clone MPS to external/mps\n"
-        "   4. Manually clone MPS: git clone https://github.com/Alexk-195/mps.git external/mps"
-    )
-endif()
-
 # Lynx static library
 add_library(lynx_static STATIC
         src/lib/lynx.cpp
@@ -125,7 +74,6 @@ target_include_directories(lynx_static PUBLIC
 
 target_link_libraries(lynx_static PUBLIC
         Threads::Threads
-        mps_static
 )
 
 set_target_properties(lynx_static PROPERTIES
@@ -152,7 +100,6 @@ target_include_directories(lynx PUBLIC
 
 target_link_libraries(lynx PUBLIC
         Threads::Threads
-        mps_static
 )
 
 set_target_properties(lynx PROPERTIES

--- a/setup.sh
+++ b/setup.sh
@@ -41,44 +41,6 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
-setup_mps() {
-    log_info "Checking for MPS library..."
-
-    # Check for MPS_PATH environment variable first
-    if [ -n "${MPS_PATH}" ] && [ -d "${MPS_PATH}" ]; then
-        export MPS_DIR="${MPS_PATH}"
-        log_info "Using MPS from MPS_PATH: ${MPS_PATH}"
-        return 0
-    fi
-
-    # Check for MPS_DIR environment variable
-    if [ -n "${MPS_DIR}" ] && [ -d "${MPS_DIR}" ]; then
-        log_info "Using MPS from MPS_DIR: ${MPS_DIR}"
-        return 0
-    fi
-
-    # Check if MPS exists in external/mps
-    local MPS_LOCAL="${PROJECT_ROOT}/external/mps"
-    if [ -d "${MPS_LOCAL}" ]; then
-        export MPS_DIR="${MPS_LOCAL}"
-        log_info "Using MPS from external/mps"
-        return 0
-    fi
-
-    # Auto-clone MPS to external/mps
-    log_warn "MPS not found. Cloning from repository..."
-    mkdir -p "${PROJECT_ROOT}/external"
-
-    if git clone https://github.com/Alexk-195/mps.git "${MPS_LOCAL}"; then
-        export MPS_DIR="${MPS_LOCAL}"
-        log_info "MPS successfully cloned to ${MPS_LOCAL}"
-    else
-        log_error "Failed to clone MPS repository"
-        log_error "You can manually set MPS_PATH or MPS_DIR environment variable"
-        exit 1
-    fi
-}
-
 setup_googletest() {
     log_info "Checking for Google Test..."
 
@@ -103,9 +65,6 @@ setup_googletest() {
 
 check_dependencies() {
     log_info "Checking dependencies..."
-
-    # Setup MPS library
-    setup_mps
 
     # Setup Google Test library
     setup_googletest


### PR DESCRIPTION
- Remove MPS library dependency from README.md
  - Remove MPS from dependencies section
  - Remove custom MPS_PATH/MPS_DIR configuration
  - Remove VectorDatabase_MPS comparison section
  - Remove reference to MPS_ARCHITECTURE.md

- Remove MPS setup from setup.sh
  - Remove setup_mps() function
  - Remove MPS dependency checks

- Remove MPS references from CLAUDE.md
  - Simplify project overview
  - Remove MPS integration section

- Remove MPS from build configuration
  - CMakeLists.txt: Remove MPS library detection and linking
  - Makefile: Remove MPS library variables and build rules

This simplifies the project by removing the optional MPS dependency that was only needed for extreme concurrency scenarios (100+ queries). The default VectorDatabase with std::shared_mutex is sufficient for most use cases.